### PR TITLE
replace PIL with Pillow because PIL is kinda deprecated and is a pain to install

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 django-appconf>=0.6
 django-model-utils>=1.4.0,<2.0
-PIL>=1.1.7,<1.2
+Pillow==2.5.1


### PR DESCRIPTION
replace PIL with Pillow 
#### What's this PR do?
- replaces `PIL` with `Pillow`
#### Why am I doing this?  How does this help us?
- `PIL` is deprecated. Other projects use this as a library and have to install `PIL`. They end up having to do silly things like `pip install --allow-unverified PIL -r requirements.txt`
#### How should this be manually tested?

`python manage.py test`.  Not sure what else. 
### Next steps:
- remove `--allow-unverified PIL` from downstream projects
